### PR TITLE
bug correction in node-trello request method when calling a DELETE http method

### DIFF
--- a/lib/node-trello.coffee
+++ b/lib/node-trello.coffee
@@ -47,7 +47,7 @@ class Trello
       method: method
       json: @addAuthArgs @parseQuery uri, args
 
-    request[method.toLowerCase()] options, (err, response, body) => callback err, body
+    request[if method is 'DELETE' then 'del' else method.toLowerCase()] options, (err, response, body) => callback err, body
 
   addAuthArgs: (args) ->
     args.key = @key


### PR DESCRIPTION
make node-trello request method to correctly call the del method of request module instead of unexistant delete method
