### PR TITLE
401 status should be treated as an error.

### DIFF
--- a/lib/node-trello.coffee
+++ b/lib/node-trello.coffee
@@ -49,7 +49,10 @@ class Trello
       method: method
       json: @addAuthArgs @parseQuery uri, args
 
-    request[if method is 'DELETE' then 'del' else method.toLowerCase()] options, (err, response, body) => callback err, body
+    request[if method is 'DELETE' then 'del' else method.toLowerCase()] options, (err, response, body) =>
+	    if response.statusCode == 401 && !err
+		    err = body
+	    callback err, body
 
   addAuthArgs: (args) ->
     args.key = @key


### PR DESCRIPTION
Currently when 401 due to an expired token the response body is "expired token" - I believe that in this context 401s should be treated as an error.

This  change pushes the "expired token" message into the error as well as the body on a 401.

Note: I couldn't see any tests covering mapping responses from requests, I started trying to add a test or two for this but there are a few too many questions I'd have before adding the first tests.
