### PR TITLE
Providing error on all HTTP error status codes.

### DIFF
--- a/lib/node-trello.coffee
+++ b/lib/node-trello.coffee
@@ -49,7 +49,13 @@ class Trello
       method: method
       json: @addAuthArgs @parseQuery uri, args
 
-    request[if method is 'DELETE' then 'del' else method.toLowerCase()] options, (err, response, body) => callback err, body
+    request[if method is 'DELETE' then 'del' else method.toLowerCase()] options, (err, response, body) =>
+      if response.statusCode >= 400 && !err
+        err = new Error(body)
+        err.statusCode = response.statusCode
+        err.responseBody = body
+        err.statusMessage = require('http').STATUS_CODES[response.statusCode]
+      callback err, body
 
   addAuthArgs: (args) ->
     args.key = @key


### PR DESCRIPTION
Based on https://github.com/adunkman/node-trello/pull/12

When the API returns an error (anything in HTTP 4xx and 5xx range) it's passed back to the user as an error.

An example is

``` javascript
var Trello = require("node-trello");
var t = new Trello("intentionally-wrong", "intentionally-wrong");

t.get("/1/boards/intentionally-wrong/cards", function (err, data) {
  if (err) {
    console.log('status:', err.statusCode);
    console.log('message:', err.statusMessage);
    console.log('body:', err.responseBody);
    throw err;
  }
  console.log('success', data);
});
```

The output is

``` bash
status: 401
message: Unauthorized
body: invalid key


Error: invalid key
```
