### PR TITLE
Check for err before checking the response code

### DIFF
--- a/lib/node-trello.coffee
+++ b/lib/node-trello.coffee
@@ -50,7 +50,7 @@ class Trello
       json: @addAuthArgs @parseQuery uri, args
 
     request[if method is 'DELETE' then 'del' else method.toLowerCase()] options, (err, response, body) =>
-      if response.statusCode >= 400 && !err
+      if !err && response.statusCode >= 400
         err = new Error(body)
         err.statusCode = response.statusCode
         err.responseBody = body


### PR DESCRIPTION
In the case where we have an error and no response object, we crash on:

TypeError: Cannot read property 'statusCode' of undefined

We should be able to assume that we have either an error or a response
object, so just switching the order in the conditional should prevent
checking the null response object.
