### PR TITLE
Fixed oauth signature.

### DIFF
--- a/lib/trello-oauth.js
+++ b/lib/trello-oauth.js
@@ -8,7 +8,7 @@ var authorizeUrl = "https://trello.com/1/OAuthAuthorizeToken";
 // loginCallback: the URL that trello redirects back to after authentication
 // appName: the name you'd like shown on trello's "authorize this app" page
 var TrelloOAuth = module.exports = function (key, secret, loginCallback, appName) {
-  this.oauth = new OAuth(requestUrl, accessUrl, key, secret, "1.0", loginCallback, "HMAC-SHA1");
+  this.oauth = new OAuth(requestUrl, accessUrl, key, secret, "1.0", loginCallback, "PLAINTEXT");
   this.appName = appName;
 };
 

--- a/lib/trello-oauth.js
+++ b/lib/trello-oauth.js
@@ -8,7 +8,7 @@ var authorizeUrl = "https://trello.com/1/OAuthAuthorizeToken";
 // loginCallback: the URL that trello redirects back to after authentication
 // appName: the name you'd like shown on trello's "authorize this app" page
 var TrelloOAuth = module.exports = function (key, secret, loginCallback, appName) {
-  this.oauth = new OAuth(requestUrl, accessUrl, key, secret, "1.0", loginCallback, "PLAINTEXT");
+  this.oauth = new OAuth(requestUrl, accessUrl, key, secret, "1.0", loginCallback, "HMAC-SHA1");
   this.appName = appName;
 };
 


### PR DESCRIPTION
According to the [trello documentation ](https://trello.com/docs/gettingstarted/oauth.html) we should use `HMAC-SHA1` oauth signature instead of `PLAINTEXT`. Using of `PLAINTEXT` causes the following error: `{"statusCode":500,"data":"Invalid Signature"}`.