### PR TITLE
add args even with attachment

### DIFF
--- a/lib/node-trello.js
+++ b/lib/node-trello.js
@@ -72,6 +72,9 @@ Trello.prototype.request = function (method, uri, argsOrCallback, callback) {
       token: this.token
     };
 
+    for (var key in args) {
+      options.formData[key] = args[key];
+    }
     if (typeof args.attachment === "string" || args.attachment instanceof String) {
       options.formData.url = args.attachment;
     }


### PR DESCRIPTION
Without this commit, the filename can't be set to name other than the original file name.
But still, there is some issue setting the mimeType.