### PR TITLE
Update request to request@2.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "oauth": "0.9.7",
-    "request": "2.51.0"
+    "request": "2.74.0"
   },
   "devDependencies": {
     "blanket": "1.1.6",


### PR DESCRIPTION
✗ Medium severity vulnerability found on request@2.51.0
- desc: Remote Memory Exposure
- info: https://snyk.io/vuln/npm:request:20160119
- from: node-trello@1.1.2 > request@2.51.0
Upgrade direct dependency request@2.51.0 to request@2.68.0

✗ Low severity vulnerability found on hawk@1.1.1
- desc: Regular Expression Denial of Service
- info: https://snyk.io/vuln/npm:hawk:20160119
- from: node-trello@1.1.2 > request@2.51.0 > hawk@1.1.1
Upgrade direct dependency request@2.51.0 to request@2.59.0 (triggers upgrades to hawk@3.1.3)