### PR TITLE
feature/request-options: add the ability to specify options for request

### DIFF
--- a/lib/node-trello.js
+++ b/lib/node-trello.js
@@ -3,14 +3,15 @@ var querystring = require("querystring");
 var OAuth = require("./trello-oauth");
 
 // Creates a new Trello request wrapper.
-// Syntax: new Trello(applicationApiKey, userToken)
-var Trello = module.exports = function (key, token) {
+// Syntax: new Trello(applicationApiKey, userToken, requestOptions)
+var Trello = module.exports = function (key, token, requestOptions) {
   if (!key) {
     throw new Error("Application API key is required");
   }
 
   this.key = key;
   this.token = token;
+  this.requestOptions = requestOptions;
   this.host = "https://api.trello.com";
 };
 
@@ -61,10 +62,10 @@ Trello.prototype.request = function (method, uri, argsOrCallback, callback) {
     url += "?" + querystring.stringify(this.addAuthArgs(this.parseQuery(uri, args)));
   }
 
-  var options = {
+  var options = Object.assign({}, this.requestOptions, {
     url: url,
     method: method
-  };
+  });
 
   if (args.attachment) {
     options.formData = {

--- a/test/trello.js
+++ b/test/trello.js
@@ -18,11 +18,15 @@ describe("Trello", function () {
       new Trello("APIKEY").should.be.ok;
     });
 
-    it("should set key and token properties", function () {
-      var trello = new Trello("APIKEY", "USERTOKEN");
+    it("should set key, token, and requestOptions properties", function () {
+      var apiKey = "APIKEY",
+        userToken = "USERTOKEN",
+        requestOptions = {option: "OPTION"};
+      var trello = new Trello(apiKey, userToken, requestOptions);
 
-      trello.key.should.equal("APIKEY");
-      trello.token.should.equal("USERTOKEN");
+      trello.key.should.equal(apiKey);
+      trello.token.should.equal(userToken);
+      trello.requestOptions.should.equal(requestOptions);
     });
   });
 
@@ -53,7 +57,13 @@ describe("Trello", function () {
         return new events.EventEmitter();
       }.bind(this);
 
-      this.trello = new Trello("APIKEY", "USERTOKEN");
+      this.requestOptions = {
+        headers: {
+          'User-Agent': 'request'
+        }
+      };
+
+      this.trello = new Trello("APIKEY", "USERTOKEN", this.requestOptions);
     });
 
     describe("#get()", function () {
@@ -178,6 +188,10 @@ describe("Trello", function () {
 
       it("should make a request with any method specified", function () {
         this.request.options.method.should.equal("VERB");
+      });
+
+      it("should include requestOptions on a request", function () {
+        this.request.options.should.containDeep(this.requestOptions);
       });
 
       it("should allow uris with a leading slash", function () {


### PR DESCRIPTION
Hi @adunkman,
Wanted to propose a change that might help some people use this library in situations where they need to manually configure the request. This might include cases where a proxy is needed, or when users may which to set custom headers. Let me know what you think.