### PR TITLE
Update mocha to 3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,13 @@
   ],
   "dependencies": {
     "blanket": "^1.2.3",
-    "mocha": "^2.5.3",
     "oauth": "^0.9.15",
-    "request": "^2.81.0",
-    "should": "^5.2.0"
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "blanket": "^1.1.6",
-    "mocha": "^2.1.0",
-    "should": "^5.1.0",
+    "mocha": "^3.4.2",
+    "should": "^5.2.0",
     "travis-cov": "^0.2.5"
   },
   "config": {


### PR DESCRIPTION
Mocha 2.5.3 introduced high severity security vulnerabilities (in growl 1.9.2 and minimatch 0.3.0), as reported by Snyk — https://snyk.io/test/npm/mocha/2.5.3

The tests run without problem using Mocha 3. AFAICS in the Mocha changelog, the breaking changes from 2 to 3 are just dropping support for older Node versions.

I've also moved Mocha and Should out of dependencies and into dev-dependencies, because they're not needed in production.